### PR TITLE
Removed tweetfloat from listdetails

### DIFF
--- a/twitter-blocker/src/tweeper/ListDetails.js
+++ b/twitter-blocker/src/tweeper/ListDetails.js
@@ -238,11 +238,7 @@ render() {
               }
               <Divider />
             </Feed>
-<<<<<<< HEAD
         {/* <TweetFloat /> */}
-=======
-        <TweetFloat/>
->>>>>>> 0def361227b57a9d05d7bb0d591e7b399ca217b5
       </Content>
     </React.Fragment>
   );

--- a/twitter-blocker/src/tweeper/ListDetails.js
+++ b/twitter-blocker/src/tweeper/ListDetails.js
@@ -212,7 +212,7 @@ render() {
               }
               <Divider />
             </Feed>
-        <TweetFloat />
+        {/* <TweetFloat /> */}
       </Content>
     </React.Fragment>
   );


### PR DESCRIPTION
# Description

Removed Tweetfloat from List Details.

Before:

<img width="1136" alt="Screen Shot 2019-05-16 at 5 27 37 PM" src="https://user-images.githubusercontent.com/46462787/57888423-248c0500-7800-11e9-801b-4c45120faf8f.png">

After:

<img width="1136" alt="Screen Shot 2019-05-16 at 5 27 55 PM" src="https://user-images.githubusercontent.com/46462787/57888431-29e94f80-7800-11e9-9bbc-cb1d1f464808.png">


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] Working Locally
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] There are no merge conflicts